### PR TITLE
Filter tab completions by current argument prefix

### DIFF
--- a/command/src/main/java/com/github/sirblobman/api/command/Command.java
+++ b/command/src/main/java/com/github/sirblobman/api/command/Command.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -518,7 +519,8 @@ public abstract class Command implements TabExecutor {
         }
 
         tabCompletions.addAll(onTabComplete(sender, args));
-        return tabCompletions;
+        return tabCompletions.stream().filter(s -> s.startsWith(args[args.length - 1]))
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
Tab completions are now filtered to only include suggestions that start with the current argument prefix, improving usability and relevance of command suggestions.